### PR TITLE
fix: allow NoCluster clustering policy and remove invalid NoEviction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This Terraform module deploys **Azure Managed Redis** (Redis Enterprise) instanc
 ## Features
 
 - Deploy Azure Managed Redis (Redis Enterprise) with various SKUs (Balanced, Memory/Compute/Flash Optimized)
-- Configurable clustering policies (EnterpriseCluster, OSSCluster, NoEviction)
+- Configurable clustering policies (EnterpriseCluster, OSSCluster, NoCluster)
 - Eviction policies (AllKeysLRU, AllKeysRandom, VolatileLRU, VolatileTTL, NoEviction)
 - Redis modules support (RediSearch, RedisJSON, RedisBloom, RedisTimeSeries)
 - TLS 1.2 support with optional non-SSL port
@@ -151,7 +151,7 @@ Default: `{}`
 Description: Clustering policy for the Redis cache:
 - `EnterpriseCluster` - Single endpoint, automatic sharding (default)
 - `OSSCluster` - Redis Cluster API protocol, best performance
-- `NoEviction` - Non-clustered mode, maximum 25GB
+- `NoCluster` - Non-clustered mode, maximum 25GB
 
 Default: "EnterpriseCluster"
 

--- a/_header.md
+++ b/_header.md
@@ -5,7 +5,7 @@ This Terraform module deploys **Azure Managed Redis** (Redis Enterprise) instanc
 ## Features
 
 - Deploy Azure Managed Redis (Redis Enterprise) with various SKUs (Balanced, Memory/Compute/Flash Optimized)
-- Configurable clustering policies (EnterpriseCluster, OSSCluster, NoEviction)
+- Configurable clustering policies (EnterpriseCluster, OSSCluster, NoCluster)
 - Eviction policies (AllKeysLRU, AllKeysRandom, VolatileLRU, VolatileTTL, NoEviction)
 - Redis modules support (RediSearch, RedisJSON, RedisBloom, RedisTimeSeries)
 - TLS 1.2 support with optional non-SSL port

--- a/variables.redis_database.tf
+++ b/variables.redis_database.tf
@@ -66,15 +66,15 @@ variable "clustering_policy" {
 Clustering policy for the Redis cache:
 - `EnterpriseCluster` - Single endpoint, automatic sharding (default)
 - `OSSCluster` - Redis Cluster API protocol, best performance
-- `NoEviction` - Non-clustered mode, maximum 25GB
+- `NoCluster` - Non-clustered mode, maximum 25GB
 
 Default: "EnterpriseCluster"
 DESCRIPTION
   nullable    = false
 
   validation {
-    condition     = contains(["EnterpriseCluster", "OSSCluster", "NoEviction"], var.clustering_policy)
-    error_message = "Clustering policy must be one of: EnterpriseCluster, OSSCluster, NoEviction"
+    condition     = contains(["EnterpriseCluster", "OSSCluster", "NoCluster"], var.clustering_policy)
+    error_message = "Clustering policy must be one of: EnterpriseCluster, OSSCluster, NoCluster"
   }
 }
 


### PR DESCRIPTION
## Description

Fixes the `clustering_policy` validation so the valid `NoCluster` value is selectable and removes the invalid `NoEviction` value from the clustering allow-list.

The ARM `Microsoft.Cache/redisEnterprise/databases` `clusteringPolicy` property only accepts `EnterpriseCluster`, `OSSCluster`, and `NoCluster` (verified against the `2025-07-01` API version this module targets). The module previously validated against `["EnterpriseCluster", "OSSCluster", "NoEviction"]` — but `NoEviction` is an *eviction*-policy value, not a clustering one.

Because the `azapi_resource` sets `schema_validation_enabled = false`, the behaviour was:
- `NoCluster` (valid) was **blocked at plan time** by the variable validation, making it impossible to deploy a non-clustered Azure Managed Redis database via the module.
- `NoEviction` (invalid) **passed plan-time validation** and was forwarded unchecked to ARM, which rejected it at apply.

### Changes
- `variables.redis_database.tf`: `clustering_policy` validation `condition`, `error_message`, and description now use `NoCluster`.
- `_header.md` / `README.md`: clustering-policy feature list and input description corrected.
- Legitimate `eviction_policy` references to `NoEviction` are intentionally left unchanged.

Fixes #36

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/Azure/terraform-azurerm-avm-res-cache-redisenterprise/blob/main/CONTRIBUTING.md).
- [x] I have followed the project's style guidelines (`terraform fmt` reports no changes).
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] `clustering_policy = "NoCluster"` passes `terraform plan`; `clustering_policy = "NoEviction"` is now rejected by validation (verified locally).
